### PR TITLE
Refactor/remove-current-location-function 브랜치 master로 merge

### DIFF
--- a/src/pages/FilteredResults.js
+++ b/src/pages/FilteredResults.js
@@ -9,10 +9,11 @@ const FilteredResults = () => {
   const location = useLocation();
   const { filters, accommodations: initialAccommodations } = location.state;
   const [accommodations, setAccommodations] = useState(initialAccommodations);
-  const [currentPosition, setCurrentPosition] = useState({
-    latitude: null,
-    longitude: null
-  });
+
+    // <사용자의 현재 위치 조회, HTTPS에서만 가능>
+  // const [currentPosition, setCurrentPosition] = useState({latitude: null, longitude: null});
+  const [currentPosition, setCurrentPosition] = useState({ latitude: 37.49082415564897, longitude: 127.03344781702127 }); // <수정>: 위치를 특정 위도와 경도로 설정
+
 
   const debouncedPosition = useDebounce(currentPosition, 500); // 500ms 디바운스 적용
 
@@ -35,20 +36,21 @@ const FilteredResults = () => {
     }
   }, [filters]);
 
-  useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          const { latitude, longitude } = position.coords;
-          setCurrentPosition({ latitude, longitude });
-          fetchFilteredAccommodations(latitude, longitude);
-        },
-        (error) => {
-          console.error("Error fetching location:", error);
-        }
-      );
-    }
-  }, [fetchFilteredAccommodations]);
+    // <사용자의 현재 위치 조회, HTTPS에서만 가능>
+  // useEffect(() => {
+  //   if (navigator.geolocation) {
+  //     navigator.geolocation.getCurrentPosition(
+  //       (position) => {
+  //         const { latitude, longitude } = position.coords;
+  //         setCurrentPosition({ latitude, longitude });
+  //         fetchFilteredAccommodations(latitude, longitude);
+  //       },
+  //       (error) => {
+  //         console.error("Error fetching location:", error);
+  //       }
+  //     );
+  //   }
+  // }, [fetchFilteredAccommodations]);
 
   useEffect(() => {
     if (debouncedPosition.latitude && debouncedPosition.longitude) {

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -15,7 +15,10 @@ const Home = () => {
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showRegisterModal, setShowRegisterModal] = useState(false);
   const [user, setUser] = useState(null);
-  const [location, setLocation] = useState({ latitude: null, longitude: null });
+
+  // <사용자의 현재 위치 조회, HTTPS에서만 가능>
+  //const [location, setLocation] = useState({ latitude: null, longitude: null });
+  const [location, setLocation] = useState({ latitude: 37.49082415564897, longitude: 127.03344781702127 }); // <수정>: 위치를 특정 위도와 경도로 설정
 
   const menuRef = useRef(null);
   const profileRef = useRef(null);
@@ -87,21 +90,22 @@ const Home = () => {
     fetchUserProfile();
   }, []);
 
-  useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          setLocation({
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-          });
-        },
-        (error) => {
-          console.error("Error fetching location:", error);
-        }
-      );
-    }
-  }, []);
+    // <사용자의 현재 위치 조회, HTTPS에서만 가능>
+  // useEffect(() => {
+  //   if (navigator.geolocation) {
+  //     navigator.geolocation.getCurrentPosition(
+  //       (position) => {
+  //         setLocation({
+  //           latitude: position.coords.latitude,
+  //           longitude: position.coords.longitude,
+  //         });
+  //       },
+  //       (error) => {
+  //         console.error("Error fetching location:", error);
+  //       }
+  //     );
+  //   }
+  // }, []);
 
   const applyFilters = async (filters) => {
     const { adults, children, infants } = filters.travelerCount;


### PR DESCRIPTION
## 현재 위치 조회 기능 제거
- getCurrentPosition(), watchPosition()은 local 또는 HTTPS에서만 사용 가능
- 현재 HTTP를 이용하기 때문에 사용자 위치 조회 기능을 사용하지 않고, 임의의 특정한 위치로 설정(코드스쿼드 건물)
```
const [currentPosition, setCurrentPosition] = useState({ latitude: 37.49082415564897, longitude: 127.03344781702127 }); // <수정>: 위치를 특정 위도와 경도로 설정
```